### PR TITLE
Tweak URL regex

### DIFF
--- a/airbnb-search-beautifier.user.js
+++ b/airbnb-search-beautifier.user.js
@@ -4,7 +4,7 @@
 // @version      0.1
 // @description  Makes search results map bigger for a better user experience
 // @author       Maxim Berezkin
-// @include      /^https?://(.+\.)?airbnb\.(\w{2-3}\.)?\w+\/.*$/
+// @include      /^https?:\/\/(.+\.)?airbnb\.(\w{2,3}\.)?\w+\/.*$/
 // @grant        none
 // ==/UserScript==
 


### PR DESCRIPTION
Hi there,

Thanks for this userscript! The same tiny map has been driving me crazy for ages.

The script works perfectly, except that it wasn't matching the AirBnb URL for me (`https://www.airbnb.co.uk/s/search-string-here`).

After a bit of trial and error on regex101.com I came up with the following change to the regex which now seems to work..

Hope this is useful for others!

Phil